### PR TITLE
Use the Aiven OpenSearch connector for Elasticsearch

### DIFF
--- a/mysql-kafka-elastic/docker-compose.yaml
+++ b/mysql-kafka-elastic/docker-compose.yaml
@@ -1,7 +1,6 @@
 ---
 services:
   zookeeper:
-    platform: linux/x86_64
     image: quay.io/debezium/zookeeper:3.2
     hostname: zookeeper
     container_name: zookeeper
@@ -11,7 +10,6 @@ services:
       - 3888:3888
 
   kafka:
-    platform: linux/x86_64
     image: quay.io/debezium/kafka:3.2
     ports:
       - 9092:9092
@@ -21,7 +19,6 @@ services:
       - zookeeper
 
   mysql:
-    platform: linux/x86_64
     image: quay.io/debezium/example-mysql:3.2
     ports:
      - 3306:3306
@@ -51,11 +48,10 @@ services:
       - 5601:5601
 
   connect:
-    image: your_registry_namespace/connect-jdbc-es:2.7
     build:
       context: docker
       args:
-        DEBEZIUM_VERSION: 2.7
+        DEBEZIUM_VERSION: 3.2.2.Final
     ports:
      - 8083:8083
      - 5005:5005
@@ -65,4 +61,4 @@ services:
      - CONFIG_STORAGE_TOPIC=my_connect_configs
      - OFFSET_STORAGE_TOPIC=my_connect_offsets
      - STATUS_STORAGE_TOPIC=my_source_connect_statuses
-     - JAVA_TOOL_OPTIONS="-XX:UseSVE=0"
+    #  - JAVA_TOOL_OPTIONS="-XX:UseSVE=0"

--- a/mysql-kafka-elastic/docker/Dockerfile
+++ b/mysql-kafka-elastic/docker/Dockerfile
@@ -1,30 +1,13 @@
-ARG DEBEZIUM_VERSION=2.7
+ARG DEBEZIUM_VERSION
 FROM quay.io/debezium/connect:${DEBEZIUM_VERSION}
 ENV KAFKA_CONNECT_JDBC_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-jdbc \
-    KAFKA_CONNECT_ES_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-elasticsearch
+    KAFKA_CONNECT_ES_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-elasticsearch \
+    KAFKA_CONNECT_OS_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-opensearch \
+    KAFKA_CONNECT_MONGODB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-mongodb
 
-ARG POSTGRES_VERSION=42.7.7
-ARG KAFKA_JDBC_VERSION=5.3.2
-ARG KAFKA_ELASTICSEARCH_VERSION=5.3.2
+ARG OPENSEARCH_VERSION=3.0.0
 
-# Deploy PostgreSQL JDBC Driver
-RUN cd /kafka/libs && curl -sO https://jdbc.postgresql.org/download/postgresql-$POSTGRES_VERSION.jar
-
-# Deploy Kafka Connect JDBC
-RUN mkdir $KAFKA_CONNECT_JDBC_DIR && cd $KAFKA_CONNECT_JDBC_DIR &&\
-	curl -sO https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/$KAFKA_JDBC_VERSION/kafka-connect-jdbc-$KAFKA_JDBC_VERSION.jar
-
-# Deploy Confluent Elasticsearch sink connector
-RUN mkdir $KAFKA_CONNECT_ES_DIR && cd $KAFKA_CONNECT_ES_DIR &&\
-        curl -sO https://packages.confluent.io/maven/io/confluent/kafka-connect-elasticsearch/$KAFKA_ELASTICSEARCH_VERSION/kafka-connect-elasticsearch-$KAFKA_ELASTICSEARCH_VERSION.jar && \
-        curl -sO https://repo1.maven.org/maven2/io/searchbox/jest/6.3.1/jest-6.3.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore-nio/4.4.4/httpcore-nio-4.4.4.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.1/httpclient-4.5.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpasyncclient/4.1.1/httpasyncclient-4.1.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar && \
-        curl -sO https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar && \
-        curl -sO https://repo1.maven.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar && \
-        curl -sO https://repo1.maven.org/maven2/io/searchbox/jest-common/6.3.1/jest-common-6.3.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.jar && \
-        curl -sO https://repo1.maven.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.jar
+# Deploy OpenSearch sink connector
+RUN mkdir $KAFKA_CONNECT_OS_DIR && cd $KAFKA_CONNECT_OS_DIR &&\
+        curl -sLO https://github.com/aiven/opensearch-connector-for-apache-kafka/releases/download/v$OPENSEARCH_VERSION/opensearch-connector-for-apache-kafka-$OPENSEARCH_VERSION.zip &&\
+        unzip opensearch-connector-for-apache-kafka-$OPENSEARCH_VERSION.zip

--- a/mysql-kafka-elastic/es-sink.json
+++ b/mysql-kafka-elastic/es-sink.json
@@ -1,7 +1,7 @@
 {
     "name": "elastic-sink",
     "config": {
-        "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+        "connector.class": "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector",
         "tasks.max": "1",
         "topics": "customers",
         "connection.url": "http://elastic:9200",


### PR DESCRIPTION
- Update to DEBEZIUM_VERSION: 3.2.2.Final.
- Reduce to minimal dependencies
- Use Opensearch connector for Elasticsearch
